### PR TITLE
api daily+weekly+monthly+yearly+total functional

### DIFF
--- a/api/src/api/models/panels.js
+++ b/api/src/api/models/panels.js
@@ -8,6 +8,7 @@ const Panel = new Schema(
         weekly: { type: [Object], default: null },
         monthly: { type: [Object], default: null },
         yearly: { type: [Object], default: null },
+        total: { type: [Object], default: null },
         zipcode: { type: Number, required: true },
         weather: { type: [String], default: null },
         timezone: {type: String, default: 'UT' },

--- a/api/src/controllers/panels-ctrl.js
+++ b/api/src/controllers/panels-ctrl.js
@@ -114,7 +114,7 @@ _getProductionHelper = async (req, panel, productionIds, estimateUnit, updateInt
         // Check Recent
         const production = await Production.findById(productionIds[index - 1])
         if (production) {
-            const recentDate = period == 't' ? production.updatedAt : production.date
+            const recentDate = (period == 't' || period == 'w') ? production.updatedAt : production.date
             const now = moment(moment.now())
             var ms = now.diff(recentDate, estimateUnit);
             if (ms < updateInterval) {
@@ -129,7 +129,7 @@ _getProductionHelper = async (req, panel, productionIds, estimateUnit, updateInt
 
     // If no production data in DB or not recent, fetch
     const newProduction = await ProductionCtrl.productionCtrl_fetchProduction(req, panel)
-    console.log(`\nGET Daily Production: MISS FETCH production ${newProduction.length}`)
+    console.log(`\nGET Production: MISS FETCH production ${newProduction.length}`)
     return newProduction
 }
 

--- a/api/src/portals/pvoutput.js
+++ b/api/src/portals/pvoutput.js
@@ -5,6 +5,9 @@ pvoutput_getProduction = async (req, numProductions) => {
     const API_KEY = '7df3ab93a0938d4acd4a261917b392df6915d076'
     const SID1 = 4612
     const SID = 82698
+    let period = req.headers.period
+    if(period == 'w') period = 'd' // Weekly needs to be added from daily
+    if(period == 't') period = 'y' // Total needs to be added from yearly
 
     const getOutputConfig = {
         params: {
@@ -32,6 +35,7 @@ pvoutput_getProduction = async (req, numProductions) => {
     }
 
     try {
+        if(req.headers.period == 't') return _getYearlyOutput(req.headers.period, getOutputConfig)
         // THIS IS FOR GETTING DAILY TOTAL OUTPUT, so update time is always 00:00 of the day
         const response = await axios.get(`https://pvoutput.org/service/r2/getoutput.jsp`, getOutputConfig)
 
@@ -85,6 +89,24 @@ _formatData = (req, parsedDataRecent) => {
     return result
 }
 
+_getYearlyOutput = async (period, getOutputConfig) => {
+    if(period != 't') return null
+
+    const response = await axios.get(`https://pvoutput.org/service/r2/getstatistic.jsp`, getOutputConfig)
+    const responseHeaders = JSON.stringify(response.headers)
+    const data = response.data
+    const status = response.status
+    
+    
+    const parsedData = data.split(',')
+
+    const field = {
+        date: parsedData[7],
+        magnitude: parsedData[0]
+    }
+    console.log(`data   ${data} parsed${parsedData}  field${field}`);
+    return [field]
+}
 module.exports = {
     pvoutput_getProduction,
 }


### PR DESCRIPTION
- Contains an edgecase where if the API request to pvoutput is very slow to respond, the server waits infinitely until it responds. This can cause the frontend to be blank for a long time. I will need to create a timer so that if pvoutput responds takes longer than, say 5 seconds, just output the data stored in cache.